### PR TITLE
Fix ColorColumn and CursorColumn highlight groups

### DIFF
--- a/colors/disco.vim
+++ b/colors/disco.vim
@@ -100,17 +100,19 @@ endif
 
 " Highlight Groups (:h highlight-groups) {{{
 
-call <SID>set_colors("ColorColumn"  , s:fg           , "NONE"         , "")
+if s:dimtwo != s:dim " Needs to be different from Comment
+	call <SID>set_colors("ColorColumn"  , "NONE"         , s:dim          , "")
+	call <SID>set_colors("CursorColumn" , "NONE"         , s:dim          , "")
+	call <SID>set_colors("CursorLine"   , "NONE"         , s:dim          , "")
+else
+	call <SID>set_colors("ColorColumn"  , "NONE"         , "NONE"         , "")
+	call <SID>set_colors("CursorColumn" , "NONE"         , "NONE"         , "")
+	call <SID>set_colors("CursorLine"   , "NONE"         , "NONE"         , "")
+endif
+
 call <SID>set_colors("Conceal"      , "NONE"         , "NONE"         , "")
 call <SID>set_colors("Cursor"       , "NONE"         , "NONE"         , "reverse")
 call <SID>set_colors("CursorIM"     , "NONE"         , "NONE"         , "")
-call <SID>set_colors("CursorColumn" , s:fg           , "NONE"         , "")
-
-if s:dimtwo != s:dim " Needs to be different from Comment
-	call <SID>set_colors("CursorLine"   , "NONE"         , s:dim          , "")
-else
-	call <SID>set_colors("CursorLine"   , "NONE"         , "NONE"          , "")
-endif
 
 call <SID>set_colors("CursorLineNr" , "NONE"         , s:dim          , "")
 call <SID>set_colors("Directory"    , s:blue         , "NONE"         , "")


### PR DESCRIPTION
Are you sure you should be setting the foreground instead of the background for colorcolumn and cursorcolumn? Because for me I don't see anything, but if I make it set the background instead, they work. So this is a PR to fix that. Also instead of `s:fg`, I decided that `s:dim` would be better, because it would be nice if it was bit different color to the normal text color. Which is why I put it in the `if` block for cursorline (and moved the block up a bit).

Hope this is okay.